### PR TITLE
When using console, should exit with error code on profanity

### DIFF
--- a/profanity_filter/console.py
+++ b/profanity_filter/console.py
@@ -43,10 +43,10 @@ def main():
     if args.show or args.output_file:
         return
 
-    if pf.is_clean(text):
-        print("This text is clean.")
-    else:
+    if pf.is_profane(text):
         print("This text is not clean!")
+        exit(1)
+    print("This text is clean.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When using `profanity_filter` endpoint, when text is profane, the program should exit with an error code

**Why is it good for us?**
I would like to use `profanity_filter` in my CI/CD process. I want to use it in order to check that nobody inserts code with profane words in it.

Now, I can use the `profanity_filter` endpoint, and if someone adds profanity to my code, it will fail the build.